### PR TITLE
Make struct types public

### DIFF
--- a/src/code_generation.rs
+++ b/src/code_generation.rs
@@ -44,7 +44,7 @@ fn recurse_types(ast: &Ast) -> Vec<ItemStruct> {
                 }
             }
             let type_name = format_ident! {"{}", type_name};
-            let struct_type = parse_quote! { struct #type_name { #(#fields),* } };
+            let struct_type = parse_quote! { pub struct #type_name { #(#fields),* } };
             let mut types = vec![struct_type];
             for child in children {
                 if let Ast::HashTable { .. } = child {


### PR DESCRIPTION
Struct types need to be public so they can be used outside the crate they are generated 