### PR TITLE
Support multi-word struct names

### DIFF
--- a/src/code_generation.rs
+++ b/src/code_generation.rs
@@ -67,7 +67,7 @@ fn recurse_types(ast: &Ast) -> Vec<ItemStruct> {
 }
 
 fn create_struct(ast: &Ast) -> TokenStream {
-    let struct_name = format_ident! {"{}", ast.get_key().to_case(Case::Upper)};
+    let struct_name = format_ident! {"{}", ast.get_key().to_case(Case::Constant)};
     let typename = format_ident! {"{}", ast.get_type_name()};
     let expr = recurse_struct(ast);
     quote! { pub const #struct_name: #typename =  #expr ;}


### PR DESCRIPTION
Currently,
```rust
#[config_to_rs(yaml, test.yaml)]
pub struct ConfigTesting;
```
produces the following error:
```
`"CONFIG TESTING"` is not a valid identifier
```
because `to_case(Case::Upper)` is used rather than `to_case(Case::Constant)`.